### PR TITLE
Update 84-enable_graphite.sh

### DIFF
--- a/openvoxserver/container-entrypoint.d/84-enable_graphite.sh
+++ b/openvoxserver/container-entrypoint.d/84-enable_graphite.sh
@@ -7,9 +7,19 @@ readonly SCRIPT_FILENAME=$(readlink -f "${BASH_SOURCE[0]}")
 readonly SCRIPT_PATH=$(dirname "$SCRIPT_FILENAME")
 
 if [[ "$OPENVOXSERVER_GRAPHITE_EXPORTER_ENABLED" == "true" ]]; then
+  # Only check for CERTNAME if graphite exporter is enabled
+  if [[ -z "$CERTNAME" ]]; then
+    echo "ERROR: CERTNAME environment variable is not set, and is required for the graphite exporter configuration."
+    exit 1
+  fi
+  
   if [[ -n "$OPENVOXSERVER_GRAPHITE_HOST" && -n "$OPENVOXSERVER_GRAPHITE_PORT" ]]; then
     echo "Enabling graphite exporter"
-    sed -e "s/GRAPHITE_HOST/$OPENVOXSERVER_GRAPHITE_HOST/" -e "s/GRAPHITE_PORT/$OPENVOXSERVER_GRAPHITE_PORT/" "$SCRIPT_PATH/84-metrics.conf.tmpl" > /etc/puppetlabs/puppetserver/conf.d/metrics.conf
+    # Use multiple -e flags to perform multiple substitutions in a single pass
+    sed -e "s/GRAPHITE_HOST/$OPENVOXSERVER_GRAPHITE_HOST/" \
+        -e "s/GRAPHITE_PORT/$OPENVOXSERVER_GRAPHITE_PORT/" \
+        -e "s/server-id: localhost/server-id: $CERTNAME/" \
+        "$SCRIPT_PATH/84-metrics.conf.tmpl" > /etc/puppetlabs/puppetserver/conf.d/metrics.conf
   else
     echo "ERROR: no OPENVOXSERVER_GRAPHITE_HOST or OPENVOXSERVER_GRAPHITE_PORT set."
     exit 99


### PR DESCRIPTION
When a Puppet infrastructure scales up to multiple compilers, a configuration change is necessary to ensure each compiler's metrics are properly identified and separated. By default, the server-id for metrics is set to localhost. This works fine for a single server, but when you have multiple compilers, all their metrics will be reported under the same localhost identifier, making it impossible to differentiate between them in your monitoring system.